### PR TITLE
Integrating Product Service via `/products` endpoint with frontend 

### DIFF
--- a/src/constants/apiPaths.ts
+++ b/src/constants/apiPaths.ts
@@ -1,9 +1,9 @@
 const API_PATHS = {
-  product: "https://.execute-api.eu-west-1.amazonaws.com/dev",
-  order: "https://.execute-api.eu-west-1.amazonaws.com/dev",
-  import: "https://.execute-api.eu-west-1.amazonaws.com/dev",
-  bff: "https://.execute-api.eu-west-1.amazonaws.com/dev",
-  cart: "https://.execute-api.eu-west-1.amazonaws.com/dev",
+  product: "https://le2d2nlv12.execute-api.eu-west-1.amazonaws.com/prod",
+  order: "https://le2d2nlv12.execute-api.eu-west-1.amazonaws.com/prod",
+  import: "https://le2d2nlv12.execute-api.eu-west-1.amazonaws.com/prod",
+  bff: "https://le2d2nlv12.execute-api.eu-west-1.amazonaws.com/prod",
+  cart: "https://le2d2nlv12.execute-api.eu-west-1.amazonaws.com/prod",
 };
 
 export default API_PATHS;

--- a/src/queries/products.ts
+++ b/src/queries/products.ts
@@ -9,7 +9,7 @@ export function useAvailableProducts() {
     "available-products",
     async () => {
       const res = await axios.get<AvailableProduct[]>(
-        `${API_PATHS.bff}/product/available`
+        `${API_PATHS.bff}/products`
       );
       return res.data;
     }


### PR DESCRIPTION
Link to Product Service API - https://le2d2nlv12.execute-api.eu-west-1.amazonaws.com/prod/
Link to CloudFront - https://d3om8esxn7ysac.cloudfront.net/
Link to BE PR - https://github.com/anyacubed/aws-shop-be/pull/1

Link to task 3 - https://github.com/rolling-scopes-school/aws/blob/main/aws-developer/03_serverless_api/task.md

- Frontend is integrated with Product Service (`/products` API) and products from Product Service are represented on Frontend
